### PR TITLE
Bug Fixes -- Refreshing after Exercise Delete, Workout Update

### DIFF
--- a/client/src/components/Dashboard/Home.js
+++ b/client/src/components/Dashboard/Home.js
@@ -21,6 +21,14 @@ import {
 import QuickStats from "./QuickStats";
 
 class Home extends Component {
+	state = {
+		refresh: false
+	}
+
+	refreshWorkouts = () => {
+		this.setState({refresh: !this.state.refresh})
+	}
+
 	componentDidUpdate = () => {
 		this.props.fetchWorkouts(this.props.userId);
 	};
@@ -40,7 +48,7 @@ class Home extends Component {
 						</div>
 						<AddWorkout />
 						<div className="right">
-							<WorkoutsList />
+							<WorkoutsList refreshWorkouts={this.refreshWorkouts}/>
 						</div>
 					</HomeBodyWrapper>
 				</DashboardContainer>

--- a/client/src/components/Exercises/Exercise.js
+++ b/client/src/components/Exercises/Exercise.js
@@ -28,6 +28,7 @@ class Exercise extends Component {
 	deleteExercise = e => {
 		e.preventDefault();
 		this.props.deleteExercise(this.props.id);
+		this.props.refreshWorkouts()
 	};
 
 	updateExercise = e => {

--- a/client/src/components/Exercises/ExerciseList.js
+++ b/client/src/components/Exercises/ExerciseList.js
@@ -21,7 +21,7 @@ class ExerciseList extends Component {
 					<TableHeaderWrapper>Weight:</TableHeaderWrapper>
 				</TableRowWrapper>
 				{this.props.exercises.map(exercise => (
-					<Exercise key={exercise.id} {...exercise} />
+					<Exercise key={exercise.id} {...exercise} refreshWorkouts={this.props.refreshWorkouts}/>
 				))}
 				<InlineAddExercise workoutId={this.props.workoutId} />
 			</TableWrapper>

--- a/client/src/components/Workouts/Workout.js
+++ b/client/src/components/Workouts/Workout.js
@@ -52,6 +52,7 @@ class Workout extends Component {
 		this.setState({
 			isEditing: !this.state.isEditing
 		});
+		this.props.refreshWorkouts()
 	};
 
 	deleteWorkout = e => {

--- a/client/src/components/Workouts/Workout.js
+++ b/client/src/components/Workouts/Workout.js
@@ -134,6 +134,7 @@ class Workout extends Component {
 						<ExerciseList
 							exercises={this.props.exercises}
 							workoutId={this.props.id}
+							refreshWorkouts={this.props.refreshWorkouts}
 						/>
 					</DropDownWrapper>
 				)}

--- a/client/src/components/Workouts/WorkoutsList.js
+++ b/client/src/components/Workouts/WorkoutsList.js
@@ -9,7 +9,7 @@ class WorkoutsList extends Component {
 		return (
 			<WorkoutsListWrapper>
 				{this.props.workouts.map(workout => (
-					<Workout key={workout.id} {...workout} />
+					<Workout key={workout.id} {...workout} refreshWorkouts={this.props.refreshWorkouts}/>
 				))}
 			</WorkoutsListWrapper>
 		);


### PR DESCRIPTION
This is a workaround that essentially triggers an update to state (refresh) in the Home component which forces another fetchWorkouts call that will update all the data. 

I wrote a method in the Home component and then passed it down as a prop to the Exercise and Workout layers

Because this is not a direct change to Redux state, there is a slight delay